### PR TITLE
Fix filter each

### DIFF
--- a/include/beman/sequence_next/detail/state_helper.hpp
+++ b/include/beman/sequence_next/detail/state_helper.hpp
@@ -18,10 +18,8 @@ struct state_helper {
 
     state_t state;
 
-    state_helper(S&& s, R&& r) : state(::beman::execution::connect(::std::forward<S>(s), ::std::forward<R>(r))) {
-    }
-    ~state_helper() {
-    }
+    state_helper(S&& s, R&& r) : state(::beman::execution::connect(::std::forward<S>(s), ::std::forward<R>(r))) {}
+    ~state_helper() {}
 
     auto start() & noexcept { ::beman::execution::start(this->state); }
 };

--- a/include/beman/sequence_next/detail/state_helper.hpp
+++ b/include/beman/sequence_next/detail/state_helper.hpp
@@ -18,7 +18,10 @@ struct state_helper {
 
     state_t state;
 
-    state_helper(S&& s, R&& r) : state(::beman::execution::connect(::std::forward<S>(s), ::std::forward<R>(r))) {}
+    state_helper(S&& s, R&& r) : state(::beman::execution::connect(::std::forward<S>(s), ::std::forward<R>(r))) {
+    }
+    ~state_helper() {
+    }
 
     auto start() & noexcept { ::beman::execution::start(this->state); }
 };

--- a/tests/beman/sequence_next/CMakeLists.txt
+++ b/tests/beman/sequence_next/CMakeLists.txt
@@ -10,6 +10,7 @@ target_sources(
     beman.sequence_next.tests
     PRIVATE
         conditional_element.test.cpp
+        filter_each.test.cpp
         sequence_next.test.cpp
         state_helper.test.cpp
 )

--- a/tests/beman/sequence_next/filter_each.test.cpp
+++ b/tests/beman/sequence_next/filter_each.test.cpp
@@ -1,0 +1,22 @@
+// tests/beman/sequence_next/filter_each.test.cpp                     -*-C++-*-
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <beman/sequence_next/sequence_next.hpp>
+#include <gtest/gtest.h>
+
+namespace sn = beman::sequence_next;
+namespace ex = beman::execution;
+
+// ----------------------------------------------------------------------------
+
+TEST(SequenceNextTest, filter_each) {
+    std::vector<int> results;
+    ex::sync_wait(sn::iota{2, 7} | sn::then_each([](auto x) { return x * 3; }) | sn::filter_each([](auto x) {
+                      static_assert(std::same_as<int, decltype(x)>);
+                      return x % 2;
+                  }) |
+                  sn::then_each([&](auto x) { results.push_back(x); }) | sn::ignore_all);
+    ASSERT_EQ(results.size(), 2);
+    EXPECT_EQ(results[0], 9);
+    EXPECT_EQ(results[1], 15);
+}

--- a/tests/beman/sequence_next/sequence_next.test.cpp
+++ b/tests/beman/sequence_next/sequence_next.test.cpp
@@ -8,15 +8,3 @@ namespace sn = beman::sequence_next;
 namespace ex = beman::execution;
 
 // ----------------------------------------------------------------------------
-
-TEST(SequenceNextTest, FilterEach) {
-    std::vector<int> results;
-    ex::sync_wait(sn::iota{2, 7} | sn::then_each([](auto x) { return x * 3; }) | sn::filter_each([](auto x) {
-                      static_assert(std::same_as<int, decltype(x)>);
-                      return x % 2;
-                  }) |
-                  sn::then_each([&](auto x) { results.push_back(x); }) | sn::ignore_all);
-    ASSERT_EQ(results.size(), 2);
-    EXPECT_EQ(results[0], 2);
-    EXPECT_EQ(results[1], 7);
-}

--- a/tests/beman/sequence_next/sequence_next.test.cpp
+++ b/tests/beman/sequence_next/sequence_next.test.cpp
@@ -8,3 +8,10 @@ namespace sn = beman::sequence_next;
 namespace ex = beman::execution;
 
 // ----------------------------------------------------------------------------
+
+TEST(SequenceNextTest, sequence_next) {
+    static_assert(std::same_as<decltype(sn::filter_each), const sn::filter_each_t>);
+    static_assert(std::same_as<decltype(sn::ignore_all), const sn::ignore_all_t>);
+    static_assert(std::same_as<decltype(sn::set_next), const sn::set_next_t>);
+    static_assert(std::same_as<decltype(sn::then_each), const sn::then_each_t>);
+}


### PR DESCRIPTION
Fixing an issue exposed by `filter_each`.  It _seems_ that issue is down to `state_helper<...>` lacking a user-defined dtor which makes me wonder if that is actually a `gcc` bug.